### PR TITLE
Fix destination_list state

### DIFF
--- a/internal/provider/resource_destination_list.go
+++ b/internal/provider/resource_destination_list.go
@@ -33,6 +33,8 @@ var _ resource.Resource = (*destinationListResource)(nil)
 const (
 	// Bundle type ID for destination lists
 	defaultBundleTypeID = 2
+	// Number of destination records to request per page
+	defaultDestinationsPageLimit = 100
 	// HTTP status codes
 	httpStatusOK       = 200
 	httpStatusNotFound = 404
@@ -57,35 +59,51 @@ type destinationListResourceModel struct {
 
 // GetDestinations retrieves destinations for a destination list
 func (r *destinationListResourceModel) GetDestinations(ctx context.Context, client *destinationlists.APIClient) ([]destinationModel, error) {
-	destinationsResp, httpRes, err := client.DestinationsAPI.GetDestinations(ctx, r.Id.ValueInt64()).Execute()
-	if err != nil {
-		var httpRespDetails string
-		if httpRes != nil {
-			httpRespDetails = fmt.Sprintf("HTTP response status: %s", httpRes.Status)
-		} else {
-			httpRespDetails = "HTTP response: <nil>"
+	page := int64(1)
+	limit := int64(defaultDestinationsPageLimit)
+	allDestinations := make([]destinationlists.DestinationObjectWithStringId, 0)
+
+	for {
+		destinationsResp, httpRes, err := client.DestinationsAPI.GetDestinations(ctx, r.Id.ValueInt64()).Page(page).Limit(limit).Execute()
+		if err != nil {
+			if httpRes != nil {
+				return nil, fmt.Errorf("error code %s reading destinations for destination list %s: %w", httpRes.Status, r.Name.ValueString(), err)
+			}
+			return nil, fmt.Errorf("error reading destinations for destination list %s: %w", r.Name.ValueString(), err)
 		}
-		return nil, fmt.Errorf("error code %s reading destinations for destination list %s: %w\n%v", httpRes.Status, r.Name.ValueString(), err, httpRespDetails)
+
+		allDestinations = append(allDestinations, destinationsResp.Data...)
+
+		total, hasTotal := destinationsResp.Meta.GetTotalOk()
+		if hasTotal && int64(len(allDestinations)) >= *total {
+			break
+		}
+
+		if int64(len(destinationsResp.Data)) < limit {
+			break
+		}
+
+		page++
 	}
 
-	destsDebug, err := json.Marshal(destinationsResp.Data)
+	destsDebug, err := json.Marshal(allDestinations)
 	if err != nil {
-		return nil, fmt.Errorf("error code %s reading destinations for destination list %s: %w", httpRes.Status, r.Name.ValueString(), err)
+		return nil, fmt.Errorf("error marshaling destinations for destination list %s: %w", r.Name.ValueString(), err)
 	}
 	tflog.Debug(ctx, "Retrieved destinations for destination list", map[string]interface{}{
 		"destination_list_id": r.Id.ValueInt64(),
 		"destinations":        string(destsDebug),
 	})
 
-	modeledDestinations := make([]destinationModel, len(destinationsResp.Data))
-	for i := range destinationsResp.Data {
+	modeledDestinations := make([]destinationModel, len(allDestinations))
+	for i := range allDestinations {
 		modeledDestinations[i] = destinationModel{
-			Id:          types.StringValue(destinationsResp.Data[i].Id),
-			Destination: types.StringValue(destinationsResp.Data[i].Destination),
-			Type:        types.StringValue(string(destinationsResp.Data[i].Type)),
+			Id:          types.StringValue(allDestinations[i].Id),
+			Destination: types.StringValue(allDestinations[i].Destination),
+			Type:        types.StringValue(string(allDestinations[i].Type)),
 		}
-		if destinationsResp.Data[i].Comment != nil {
-			modeledDestinations[i].Comment = types.StringValue(*destinationsResp.Data[i].Comment)
+		if allDestinations[i].Comment != nil {
+			modeledDestinations[i].Comment = types.StringValue(*allDestinations[i].Comment)
 		}
 	}
 

--- a/internal/provider/resource_destination_list_test.go
+++ b/internal/provider/resource_destination_list_test.go
@@ -6,6 +6,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -113,6 +114,30 @@ func TestAccDestinationList_addDestination(t *testing.T) {
 	}, minWaitTime)
 }
 
+func TestAccDestinationList_threeHundredDestinations(t *testing.T) {
+	rateLimitedTest(t, func() {
+		testName := generateDestinationListTestName("three_hundred_destinations")
+
+		resource.Test(t, resource.TestCase{
+			PreCheck:                 func() { testAccPreCheck(t) },
+			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
+			Steps: []resource.TestStep{
+				{
+					Config: testAccDestinationListThreeHundredDestinationsConfig(testName),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttrSet(testDestinationListResourceName, "id"),
+						resource.TestCheckResourceAttr(testDestinationListResourceName, "name", testName),
+						resource.TestCheckResourceAttr(testDestinationListResourceName, "destinations.#", "300"),
+					),
+					ConfigStateChecks: []statecheck.StateCheck{
+						statecheck.ExpectKnownValue(testDestinationListResourceName, tfjsonpath.New("destinations"), knownvalue.SetSizeExact(300)),
+					},
+				},
+			},
+		})
+	}, minWaitTime)
+}
+
 // Helper functions
 
 // generateDestinationListTestName creates a unique test name with the given suffix
@@ -165,4 +190,25 @@ resource "ciscosecureaccess_destination_list" "acceptance_list" {
       },
     ]
 }`, name)
+}
+
+// testAccDestinationListThreeHundredDestinationsConfig returns a destination list configuration with 300 destinations
+func testAccDestinationListThreeHundredDestinationsConfig(name string) string {
+	var destinations strings.Builder
+
+	for i := 1; i <= 300; i++ {
+		destinations.WriteString(fmt.Sprintf(`      {
+        comment = "Destination %d managed by TF"
+        type = "domain"
+        destination = "dest%d.example.com"
+      },
+`, i, i))
+	}
+
+	return fmt.Sprintf(`
+resource "ciscosecureaccess_destination_list" "acceptance_list" {
+    name = "%s"
+    destinations = [
+%s    ]
+}`, name, destinations.String())
 }


### PR DESCRIPTION
Fixes an issue with storing state in terraform if more than 25 destinations
are included in a destination_list.  Destination Lists aren't implemented in lists,
rather as a collection of child destinations.  Page through the destinations in sets
of 100 to add to state.

Fixes #11 

## Testing

Tested working with:
```
resource "ciscosecureaccess_destination_list" "test_dl_scale" {
    name = "TF Dest List Scale"
    destinations = [
      for i in range(1, 301) : {
        comment = "Domain #${i}"
        type = "domain"
        destination = "test${i}.example.com"
      }
    ]
}
```