### PR TITLE
Fixes for Destinations

### DIFF
--- a/internal/provider/resource_destination_list.go
+++ b/internal/provider/resource_destination_list.go
@@ -325,7 +325,16 @@ func validateDestinationForType(destinationType string, destination string) erro
 
 func isValidIPv4(value string) bool {
 	parsed := net.ParseIP(value)
-	return parsed != nil && parsed.To4() != nil
+	if parsed != nil && parsed.To4() != nil {
+		return true
+	}
+
+	_, cidr, err := net.ParseCIDR(value)
+	if err != nil || cidr == nil {
+		return false
+	}
+
+	return cidr.IP.To4() != nil
 }
 
 func isValidDomain(value string) bool {

--- a/internal/provider/resource_destination_list_test.go
+++ b/internal/provider/resource_destination_list_test.go
@@ -103,10 +103,10 @@ func TestAccDestinationList_addDestination(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttrSet(testDestinationListResourceName, "id"),
 						resource.TestCheckResourceAttr(testDestinationListResourceName, "name", testName),
-						resource.TestCheckResourceAttr(testDestinationListResourceName, "destinations.#", "3"),
+						resource.TestCheckResourceAttr(testDestinationListResourceName, "destinations.#", "7"),
 					),
 					ConfigStateChecks: []statecheck.StateCheck{
-						statecheck.ExpectKnownValue(testDestinationListResourceName, tfjsonpath.New("destinations"), knownvalue.SetSizeExact(3)),
+						statecheck.ExpectKnownValue(testDestinationListResourceName, tfjsonpath.New("destinations"), knownvalue.SetSizeExact(7)),
 					},
 				},
 			},
@@ -154,12 +154,12 @@ resource "ciscosecureaccess_destination_list" "acceptance_list" {
     name = "%s"
     destinations = [
       {
-        comment = "First test destination managed by TF"
+        comment = "IP destination"
         type = "ipv4"
         destination = "127.0.0.2"
       },
       {
-        comment = "Second test destination managed by TF"
+        comment = "URL destination"
         type = "url"
         destination = "http://example.com/test"
       },
@@ -174,19 +174,39 @@ resource "ciscosecureaccess_destination_list" "acceptance_list" {
     name = "%s"
     destinations = [
       {
-        comment = "First test destination managed by TF"
+        comment = "IP destination"
         type = "ipv4"
         destination = "127.0.0.2"
       },
       {
-        comment = "Second test destination managed by TF"
+        comment = "URL destination"
         type = "url"
         destination = "http://example.com/test"
       },
       {
-        comment = "Third test destination to test state update"
+        comment = "CIDR destination"
+        type = "ipv4"
+        destination = "192.168.1.0/24"
+      },
+      {
+        comment = "Domain destination"
+        type = "domain"
+        destination = "bar.baz"
+      },
+      {
+        comment = "Sub domain destination"
         type = "domain"
         destination = "foo.bar.baz"
+      },
+      {
+        comment = "Country code domain destination"
+        type = "domain"
+        destination = "us"
+      },
+      {
+        comment = "TLD destination"
+        type = "domain"
+        destination = "com"
       },
     ]
 }`, name)

--- a/internal/provider/resource_destination_list_validation_test.go
+++ b/internal/provider/resource_destination_list_validation_test.go
@@ -19,6 +19,10 @@ func TestValidateDestinationForType_ipv4(t *testing.T) {
 		t.Fatalf("expected valid IPv4 destination, got error: %v", err)
 	}
 
+	if err := validateDestinationForType(string(ipv4Type), "192.168.0.0/16"); err != nil {
+		t.Fatalf("expected valid IPv4 destination, got error: %v", err)
+	}
+
 	if err := validateDestinationForType(string(ipv4Type), "example.com"); err == nil {
 		t.Fatal("expected invalid IPv4 destination error, got nil")
 	}
@@ -60,5 +64,34 @@ func TestValidateDestinationForType_url(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "domain") {
 		t.Fatalf("expected domain recommendation in error, got: %v", err)
+	}
+}
+
+func TestValidateDestinationExtraCases(t *testing.T) {
+	// domain with two labels should be valid
+	domainType, ok := allowedDestinationTypeByName("domain")
+	if !ok {
+		t.Fatal("expected domain type in destinationlists.AllowedModelTypeEnumValues")
+	}
+
+	if err := validateDestinationForType(string(domainType), "bar.gaz"); err != nil {
+		t.Fatalf("expected valid domain destination 'bar.gaz', got error: %v", err)
+	}
+
+	// single-label domains should be valid
+	if err := validateDestinationForType(string(domainType), "us"); err != nil {
+		t.Fatalf("expected valid domain destination 'us', got error: %v", err)
+	}
+	if err := validateDestinationForType(string(domainType), "com"); err != nil {
+		t.Fatalf("expected valid domain destination 'com', got error: %v", err)
+	}
+
+	// CIDR block should be valid for IPV4 type
+	ipv4Type, ok := allowedDestinationTypeByName("ipv4")
+	if !ok {
+		t.Fatal("expected ipv4 type in destinationlists.AllowedModelTypeEnumValues")
+	}
+	if err := validateDestinationForType(string(ipv4Type), "192.168.1.0/24"); err != nil {
+		t.Fatalf("expected valid IPv4/CIDR destination '192.168.1.0/24', got error: %v", err)
 	}
 }


### PR DESCRIPTION
* Add strict checking of destination property against type property.  Destination type may be normalized on server after POST without notification, causing terraform state update failures.

* Page through destinations when POSTing large batches. Destinations API has a 500 destination limit, but advertises no maxItems in API spec