### PR TITLE
Runtime bug fixes

### DIFF
--- a/internal/provider/data_source_connector_group.go
+++ b/internal/provider/data_source_connector_group.go
@@ -122,12 +122,18 @@ func (d *resourceConnectorGroupsDataSource) Metadata(ctx context.Context, req da
 	resp.TypeName = req.ProviderTypeName + "_resource_connector"
 }
 
-func (d *resourceConnectorGroupsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+func (d *resourceConnectorGroupsDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	d.client = *req.ProviderData.(*client.SSEClientFactory).GetResConnClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	d.client = *factory.GetResConnClient(ctx)
 }
 
 // Read retrieves the resource connector groups from the API and sets the state.

--- a/internal/provider/data_source_group.go
+++ b/internal/provider/data_source_group.go
@@ -57,12 +57,18 @@ func (d *groupDataSource) Metadata(ctx context.Context, req datasource.MetadataR
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *groupDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+func (d *groupDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	d.client = *req.ProviderData.(*client.SSEClientFactory).GetReportsClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	d.client = *factory.GetReportsClient(ctx)
 }
 
 // Schema defines the schema for the data source.

--- a/internal/provider/data_source_identity.go
+++ b/internal/provider/data_source_identity.go
@@ -67,12 +67,18 @@ func (d *identityDataSource) Metadata(ctx context.Context, req datasource.Metada
 }
 
 // Configure adds the provider configured client to the data source.
-func (d *identityDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, _ *datasource.ConfigureResponse) {
+func (d *identityDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	d.client = *req.ProviderData.(*client.SSEClientFactory).GetReportsClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	d.client = *factory.GetReportsClient(ctx)
 }
 
 // Schema defines the schema for the data source.

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -301,8 +301,9 @@ func (r *accessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 				httpRes.Body.Close()
 			}
 
-			respString, _ := json.Marshal(createResp)
-			log.Printf("[DEBUG] Created access policy: %s", respString)
+			if respBytes, err := json.Marshal(createResp); err == nil {
+				log.Printf("[DEBUG] Created access policy: %s", respBytes)
+			}
 
 			plan.Priority = types.Int64Value(createResp.GetRulePriority())
 			plan.ID = types.Int64Value(createResp.GetRuleId())
@@ -342,8 +343,9 @@ func formatCreateAccessPolicyRequest(ctx context.Context, plan *accessPolicyReso
 
 	// Log the conditions for debugging
 	if len(ruleConditionsList) > 0 {
-		conditionString, _ := json.Marshal(ruleConditionsList)
-		log.Printf("[DEBUG] Rule conditions: %s", conditionString)
+		if conditionBytes, err := json.Marshal(ruleConditionsList); err == nil {
+			log.Printf("[DEBUG] Rule conditions: %s", conditionBytes)
+		}
 	}
 
 	// Create rule definition
@@ -534,8 +536,9 @@ func (r *accessPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 			return
 		}
 
-		updateString, _ := json.Marshal(updateRule)
-		log.Printf("[DEBUG] Update response for access policy ID %s: %s", plan.ID.String(), updateString)
+		if updateBytes, err := json.Marshal(updateRule); err == nil {
+			log.Printf("[DEBUG] Update response for access policy ID %s: %s", plan.ID.String(), updateBytes)
+		}
 	}
 
 	// Set the updated state

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -271,12 +271,10 @@ func (r *accessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 	err := retry.Do(
 		func() error {
 			createResp, httpRes, err := r.client.AccessRulesAPI.AddRule(ctx).AddRuleRequest(*ruleDefinition).Execute()
-			if httpRes != nil {
-				defer httpRes.Body.Close()
-			}
 			if err != nil {
 				if httpRes != nil {
 					bodyBytes, _ := io.ReadAll(httpRes.Body)
+					httpRes.Body.Close()
 					bodyStr := string(bodyBytes)
 
 					// Retryable errors
@@ -292,6 +290,9 @@ func (r *accessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 				// Unknown error without response
 				resp.Diagnostics.AddError("Error creating access policy", err.Error())
 				return retry.Unrecoverable(err)
+			}
+			if httpRes != nil {
+				httpRes.Body.Close()
 			}
 
 			respString, _ := json.Marshal(createResp)

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -404,6 +404,7 @@ func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadReques
 		)
 		return
 	}
+	defer httpRes.Body.Close()
 
 	// Parse rule conditions from API response
 	for _, condition := range readResp.RuleConditions {
@@ -555,6 +556,9 @@ func (r *accessPolicyResource) Delete(ctx context.Context, req resource.DeleteRe
 	err := retry.Do(
 		func() error {
 			httpRes, err := r.client.AccessRulesAPI.DeleteRule(ctx, state.ID.ValueInt64()).Execute()
+			if httpRes != nil {
+				defer httpRes.Body.Close()
+			}
 			if err != nil {
 				if httpRes != nil && httpRes.StatusCode == 404 {
 					// Resource already deleted

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -110,12 +110,18 @@ func (r *accessPolicyResource) Metadata(_ context.Context, req resource.Metadata
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *accessPolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *accessPolicyResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetRulesClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetRulesClient(ctx)
 }
 
 // Schema defines the schema for the resource.

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -405,9 +405,13 @@ func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadReques
 		case condition.AttributeName.AttributeNameDestination != nil:
 			switch string(*condition.AttributeName.AttributeNameDestination) {
 			case "umbrella.destination.private_resource_ids":
-				state.PrivateResourceIds, _ = types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				v, d := types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				resp.Diagnostics.Append(d...)
+				state.PrivateResourceIds = v
 			case "umbrella.destination.destination_list_ids":
-				state.DestinationListIds, _ = types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				v, d := types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				resp.Diagnostics.Append(d...)
+				state.DestinationListIds = v
 			case "umbrella.destination.private_resource_types":
 				var typeNames []string
 				for _, typeId := range *condition.AttributeValue.ArrayOfString {
@@ -415,11 +419,15 @@ func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadReques
 						typeNames = append(typeNames, PRIVATE_APPS_SCHEMA)
 					}
 				}
-				state.PrivateDestinationTypes, _ = types.SetValueFrom(ctx, types.StringType, typeNames)
+				v, d := types.SetValueFrom(ctx, types.StringType, typeNames)
+				resp.Diagnostics.Append(d...)
+				state.PrivateDestinationTypes = v
 			case "umbrella.destination.all":
 				if condition.AttributeValue.Bool != nil && *condition.AttributeValue.Bool {
 					publicTypes := []string{PUBLIC_INTERNET_SCHEMA}
-					state.PublicDestinationTypes, _ = types.SetValueFrom(ctx, types.StringType, publicTypes)
+					v, d := types.SetValueFrom(ctx, types.StringType, publicTypes)
+					resp.Diagnostics.Append(d...)
+					state.PublicDestinationTypes = v
 				}
 			}
 		case condition.AttributeName.AttributeNameSource != nil:
@@ -433,9 +441,13 @@ func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadReques
 						typeNames = append(typeNames, NETWORKS)
 					}
 				}
-				state.SourceTypes, _ = types.SetValueFrom(ctx, types.StringType, typeNames)
+				v, d := types.SetValueFrom(ctx, types.StringType, typeNames)
+				resp.Diagnostics.Append(d...)
+				state.SourceTypes = v
 			case "umbrella.source.identity_ids":
-				state.SourceIds, _ = types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				v, d := types.SetValueFrom(ctx, types.Int64Type, condition.AttributeValue.ArrayOfInt64)
+				resp.Diagnostics.Append(d...)
+				state.SourceIds = v
 			}
 		}
 	}

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -270,7 +270,7 @@ func (r *accessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 
 	err := retry.Do(
 		func() error {
-			createResp, httpRes, err := r.client.AccessRulesAPI.AddRule(context.Background()).AddRuleRequest(*ruleDefinition).Execute()
+			createResp, httpRes, err := r.client.AccessRulesAPI.AddRule(ctx).AddRuleRequest(*ruleDefinition).Execute()
 			if httpRes != nil {
 				defer httpRes.Body.Close()
 			}
@@ -310,6 +310,7 @@ func (r *accessPolicyResource) Create(ctx context.Context, req resource.CreateRe
 		},
 		retry.Delay(time.Second*10), // More reasonable delay
 		retry.Attempts(6),
+		retry.Context(ctx),
 	)
 
 	if err != nil {

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -368,9 +368,8 @@ func formatCreateAccessPolicyRequest(ctx context.Context, plan *accessPolicyReso
 func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
 	// Get current state
 	var state accessPolicyResourceModel
-	diags := req.State.Get(ctx, &state)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
 	if resp.Diagnostics.HasError() {
-		resp.Diagnostics.Append(diags...)
 		return
 	}
 

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -383,12 +383,12 @@ func (r *accessPolicyResource) Read(ctx context.Context, req resource.ReadReques
 	tflog.Debug(ctx, "Retrieving access policy", map[string]interface{}{"id": resourceId})
 
 	readResp, httpRes, err := r.client.AccessRulesAPI.GetRule(ctx, resourceId).Execute()
-	if httpRes != nil && httpRes.StatusCode == 404 {
-		tflog.Info(ctx, "Access policy not found, removing from state", map[string]interface{}{"id": resourceId})
-		resp.State.RemoveResource(ctx)
-		return
-	}
 	if err != nil {
+		if httpRes != nil && httpRes.StatusCode == 404 {
+			tflog.Info(ctx, "Access policy not found, removing from state", map[string]interface{}{"id": resourceId})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error reading access policy",
 			fmt.Sprintf("Cannot read access policy ID %d: %s", resourceId, err.Error()),
@@ -555,15 +555,15 @@ func (r *accessPolicyResource) Delete(ctx context.Context, req resource.DeleteRe
 	err := retry.Do(
 		func() error {
 			httpRes, err := r.client.AccessRulesAPI.DeleteRule(ctx, state.ID.ValueInt64()).Execute()
-			if httpRes != nil && httpRes.StatusCode == 404 {
-				// Resource already deleted
-				return nil
-			}
-			if err != nil && httpRes != nil && httpRes.StatusCode == 409 {
-				// Conflict - retry
-				return fmt.Errorf("conflict deleting access policy: %v", httpRes.StatusCode)
-			}
 			if err != nil {
+				if httpRes != nil && httpRes.StatusCode == 404 {
+					// Resource already deleted
+					return nil
+				}
+				if httpRes != nil && httpRes.StatusCode == 409 {
+					// Conflict - retry
+					return fmt.Errorf("conflict deleting access policy: %v", httpRes.StatusCode)
+				}
 				return retry.Unrecoverable(fmt.Errorf("failed to delete access policy: %w", err))
 			}
 			return nil

--- a/internal/provider/resource_access_policy.go
+++ b/internal/provider/resource_access_policy.go
@@ -515,7 +515,10 @@ func (r *accessPolicyResource) Update(ctx context.Context, req resource.UpdateRe
 			baseline.RuleSettings,
 		)
 
-		updateRule, _, err := r.client.AccessRulesAPI.PutRule(ctx, plan.ID.ValueInt64()).PutRuleRequest(*payload).Execute()
+		updateRule, httpRes, err := r.client.AccessRulesAPI.PutRule(ctx, plan.ID.ValueInt64()).PutRuleRequest(*payload).Execute()
+		if httpRes != nil {
+			defer httpRes.Body.Close()
+		}
 		if err != nil {
 			resp.Diagnostics.AddError(
 				"Error updating access policy",

--- a/internal/provider/resource_destination_list.go
+++ b/internal/provider/resource_destination_list.go
@@ -225,12 +225,18 @@ func (r *destinationListResource) Schema(ctx context.Context, req resource.Schem
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *destinationListResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *destinationListResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetDestinationListsClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetDestinationListsClient(ctx)
 }
 
 func (r *destinationListResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {

--- a/internal/provider/resource_global_settings.go
+++ b/internal/provider/resource_global_settings.go
@@ -47,12 +47,18 @@ type globalSettingsResourceModel struct {
 }
 
 // Configure adds the provider configured client to the resource
-func (r *globalSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *globalSettingsResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetRulesClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetRulesClient(ctx)
 	tflog.Debug(ctx, "Configured global settings resource client")
 }
 

--- a/internal/provider/resource_internal_network.go
+++ b/internal/provider/resource_internal_network.go
@@ -58,12 +58,18 @@ func (r *internalNetworkResource) Metadata(_ context.Context, req resource.Metad
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *internalNetworkResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *internalNetworkResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetInternalNetworksClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetInternalNetworksClient(ctx)
 }
 
 // Schema defines the schema for the resource.

--- a/internal/provider/resource_ntg.go
+++ b/internal/provider/resource_ntg.go
@@ -86,12 +86,18 @@ func (r *networkTunnelGroupResource) Metadata(_ context.Context, req resource.Me
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *networkTunnelGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *networkTunnelGroupResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetNtgClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetNtgClient(ctx)
 }
 
 // Schema defines the schema for the resource.

--- a/internal/provider/resource_ntg.go
+++ b/internal/provider/resource_ntg.go
@@ -275,12 +275,12 @@ func (r *networkTunnelGroupResource) Read(ctx context.Context, req resource.Read
 	tflog.Debug(ctx, "Reading network tunnel group", map[string]interface{}{"id": tunnelId})
 
 	readResp, httpRes, err := r.client.NetworkTunnelGroupsAPI.GetNetworkTunnelGroup(ctx, tunnelId).Execute()
-	if httpRes != nil && httpRes.StatusCode == 404 {
-		tflog.Info(ctx, "Network tunnel group not found, removing from state", map[string]interface{}{"id": tunnelId})
-		resp.State.RemoveResource(ctx)
-		return
-	}
 	if err != nil {
+		if httpRes != nil && httpRes.StatusCode == 404 {
+			tflog.Info(ctx, "Network tunnel group not found, removing from state", map[string]interface{}{"id": tunnelId})
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error reading network tunnel group",
 			fmt.Sprintf("Could not read network tunnel group ID %d: %s", tunnelId, err.Error()),
@@ -467,12 +467,12 @@ func (r *networkTunnelGroupResource) Delete(ctx context.Context, req resource.De
 
 	// Delete existing tunnel
 	httpRes, err := r.client.NetworkTunnelGroupsAPI.DeleteNetworkTunnelGroup(ctx, tunnelId).Execute()
-	if httpRes != nil && httpRes.StatusCode == 404 {
-		// Resource already deleted
-		tflog.Info(ctx, "Network tunnel group already deleted", map[string]interface{}{"id": tunnelId})
-		return
-	}
 	if err != nil {
+		if httpRes != nil && httpRes.StatusCode == 404 {
+			// Resource already deleted
+			tflog.Info(ctx, "Network tunnel group already deleted", map[string]interface{}{"id": tunnelId})
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Error deleting network tunnel group",
 			fmt.Sprintf("Could not delete tunnel group ID %d: %s", tunnelId, err.Error()),

--- a/internal/provider/resource_private_resource.go
+++ b/internal/provider/resource_private_resource.go
@@ -474,7 +474,14 @@ func (r *privateResourceResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	policyId, _ := strconv.Atoi(state.ID.ValueString())
+	policyId, idErr := strconv.Atoi(state.ID.ValueString())
+	if idErr != nil {
+		resp.Diagnostics.AddError(
+			"Invalid resource ID",
+			fmt.Sprintf("Could not parse resource ID %q: %s", state.ID.ValueString(), idErr),
+		)
+		return
+	}
 	tflog.Debug(ctx, "Retrieving upstream policy", map[string]interface{}{
 		"policy_id": policyId,
 	})
@@ -660,7 +667,10 @@ func (r *privateResourceResource) updatePrivateResource(ctx context.Context, pla
 		payload.SetCertificateId(*baseline.CertificateId)
 	}
 
-	id, _ := strconv.Atoi(plan.ID.ValueString())
+	id, idErr := strconv.Atoi(plan.ID.ValueString())
+	if idErr != nil {
+		return fmt.Errorf("invalid resource ID %q: %w", plan.ID.ValueString(), idErr)
+	}
 	updateResp, _, err := r.client.PrivateResourcesAPI.PutPrivateResource(ctx, int64(id)).PrivateResourceRequest(*payload).Execute()
 
 	if err != nil {
@@ -689,7 +699,14 @@ func (r *privateResourceResource) Delete(ctx context.Context, req resource.Delet
 		return
 	}
 
-	id, _ := strconv.Atoi(state.ID.ValueString())
+	id, idErr := strconv.Atoi(state.ID.ValueString())
+	if idErr != nil {
+		resp.Diagnostics.AddError(
+			"Invalid resource ID",
+			fmt.Sprintf("Could not parse resource ID %q: %s", state.ID.ValueString(), idErr),
+		)
+		return
+	}
 	tflog.Info(ctx, "Deleting private resource", map[string]interface{}{
 		"resource_id": id,
 	})

--- a/internal/provider/resource_private_resource.go
+++ b/internal/provider/resource_private_resource.go
@@ -719,11 +719,11 @@ func (r *privateResourceResource) Delete(ctx context.Context, req resource.Delet
 
 	// Delete existing private resource
 	delResp, httpRes, err := r.client.PrivateResourcesAPI.DeletePrivateResource(ctx, int64(id)).Execute()
-	if httpRes != nil && httpRes.StatusCode == privateResourceHTTPNotFound {
-		tflog.Debug(ctx, "Private resource not found, already deleted")
-		return
-	}
 	if err != nil {
+		if httpRes != nil && httpRes.StatusCode == privateResourceHTTPNotFound {
+			tflog.Debug(ctx, "Private resource not found, already deleted")
+			return
+		}
 		var httpRespDetails string
 		if httpRes != nil {
 			httpRespDetails = fmt.Sprintf("HTTP response status: %d", httpRes.StatusCode)

--- a/internal/provider/resource_private_resource.go
+++ b/internal/provider/resource_private_resource.go
@@ -109,12 +109,18 @@ func (r *privateResourceResource) Metadata(_ context.Context, req resource.Metad
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *privateResourceResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *privateResourceResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetPrivateAppsClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetPrivateAppsClient(ctx)
 	tflog.Debug(ctx, "Configured private resource client")
 }
 

--- a/internal/provider/resource_resource_connector_agent.go
+++ b/internal/provider/resource_resource_connector_agent.go
@@ -295,7 +295,9 @@ func (r *resourceConnectorAgentResource) processConnectorResponse(ctx context.Co
 
 			state := *data
 			state.LoadFromAPI(ctx, agent)
-			r.Synchronize(ctx, &state, data)
+			if err := r.Synchronize(ctx, &state, data); err != nil {
+				return fmt.Errorf("failed to synchronize connector agent: %w", err)
+			}
 			*data = state
 
 			tflog.Info(ctx, "Successfully configured resource connector agent", map[string]interface{}{
@@ -409,7 +411,13 @@ func (r *resourceConnectorAgentResource) Update(ctx context.Context, req resourc
 	})
 
 	// Update API call logic
-	r.Synchronize(ctx, &state, &plan)
+	if err := r.Synchronize(ctx, &state, &plan); err != nil {
+		resp.Diagnostics.AddError(
+			"Error updating resource connector agent",
+			fmt.Sprintf("Failed to synchronize connector agent %d: %v", agentID, err),
+		)
+		return
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -419,8 +427,10 @@ func (r *resourceConnectorAgentResource) Update(ctx context.Context, req resourc
 	})
 }
 
-// Synchronize updates the resource connector agent based on plan changes
-func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state *resourceConnectorAgentResourceModel, plan *resourceConnectorAgentResourceModel) {
+// Synchronize updates the resource connector agent based on plan changes.
+// It returns an error if any patch operation fails so callers can gate
+// state writes on success and avoid silent state drift.
+func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state *resourceConnectorAgentResourceModel, plan *resourceConnectorAgentResourceModel) error {
 	agentID := state.ID.ValueInt64()
 
 	// Update confirmed status if changed
@@ -435,10 +445,10 @@ func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state 
 				"agent_id": agentID,
 				"error":    err.Error(),
 			})
-		} else {
-			state.Confirmed = plan.Confirmed
-			tflog.Debug(ctx, "Successfully updated confirmed status")
+			return fmt.Errorf("failed to update confirmed status: %w", err)
 		}
+		state.Confirmed = plan.Confirmed
+		tflog.Debug(ctx, "Successfully updated confirmed status")
 	}
 
 	// Update enabled status if changed
@@ -453,11 +463,13 @@ func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state 
 				"agent_id": agentID,
 				"error":    err.Error(),
 			})
-		} else {
-			state.Enabled = plan.Enabled
-			tflog.Debug(ctx, "Successfully updated enabled status")
+			return fmt.Errorf("failed to update enabled status: %w", err)
 		}
+		state.Enabled = plan.Enabled
+		tflog.Debug(ctx, "Successfully updated enabled status")
 	}
+
+	return nil
 }
 
 // patchConnectorField updates a single field on the connector using PATCH operation

--- a/internal/provider/resource_resource_connector_agent.go
+++ b/internal/provider/resource_resource_connector_agent.go
@@ -79,7 +79,13 @@ func (r *resourceConnectorAgentResource) Configure(ctx context.Context, req reso
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetResConnClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetResConnClient(ctx)
 	tflog.Debug(ctx, "Configured resource connector agent client")
 }
 

--- a/internal/provider/resource_resource_connector_agent.go
+++ b/internal/provider/resource_resource_connector_agent.go
@@ -265,10 +265,11 @@ func (r *resourceConnectorAgentResource) processConnectorResponse(ctx context.Co
 
 	// Try to use reflection to understand the structure
 	if agents != nil {
-		respBytes, _ := json.Marshal(agents)
-		tflog.Debug(ctx, "ListConnectors response data", map[string]interface{}{
-			"data": string(respBytes),
-		})
+		if respBytes, err := json.Marshal(agents); err == nil {
+			tflog.Debug(ctx, "ListConnectors response data", map[string]interface{}{
+				"data": string(respBytes),
+			})
+		}
 	}
 
 	// Try direct type assertion for the specific ConnectorListRes type
@@ -294,10 +295,11 @@ func (r *resourceConnectorAgentResource) processConnectorResponse(ctx context.Co
 		}
 
 		for _, agent := range connectorListRes.GetData() {
-			respString, _ := json.Marshal(agent)
-			tflog.Debug(ctx, "Found resource connector agent", map[string]interface{}{
-				"agent_data": string(respString),
-			})
+			if respBytes, err := json.Marshal(agent); err == nil {
+				tflog.Debug(ctx, "Found resource connector agent", map[string]interface{}{
+					"agent_data": string(respBytes),
+				})
+			}
 
 			state := *data
 			state.LoadFromAPI(ctx, agent)
@@ -440,7 +442,7 @@ func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state 
 	agentID := state.ID.ValueInt64()
 
 	// Update confirmed status if changed
-	if plan.Confirmed.ValueBool() && plan.Confirmed.ValueBool() != state.Confirmed.ValueBool() {
+	if plan.Confirmed.ValueBool() != state.Confirmed.ValueBool() {
 		tflog.Debug(ctx, "Updating resource connector agent confirmed status", map[string]interface{}{
 			"agent_id":  agentID,
 			"confirmed": plan.Confirmed.ValueBool(),
@@ -458,7 +460,7 @@ func (r *resourceConnectorAgentResource) Synchronize(ctx context.Context, state 
 	}
 
 	// Update enabled status if changed
-	if plan.Enabled.ValueBool() && plan.Enabled.ValueBool() != state.Enabled.ValueBool() {
+	if plan.Enabled.ValueBool() != state.Enabled.ValueBool() {
 		tflog.Debug(ctx, "Updating resource connector agent enabled status", map[string]interface{}{
 			"agent_id": agentID,
 			"enabled":  plan.Enabled.ValueBool(),

--- a/internal/provider/resource_resource_connector_agent.go
+++ b/internal/provider/resource_resource_connector_agent.go
@@ -204,12 +204,11 @@ func (r *resourceConnectorAgentResource) findAndConfigureAgent(ctx context.Conte
 	return retry.Do(
 		func() error {
 			agents, httpRes, err := r.client.ConnectorsAPI.ListConnectors(ctx).Filters(filters).Execute()
-			if httpRes != nil && httpRes.Body != nil {
-				httpRes.Body.Close()
-			}
-
 			if err != nil {
 				return r.handleListConnectorsError(ctx, httpRes, err)
+			}
+			if httpRes != nil && httpRes.Body != nil {
+				httpRes.Body.Close()
 			}
 
 			return r.processConnectorResponse(ctx, agents, data, filters)
@@ -225,6 +224,7 @@ func (r *resourceConnectorAgentResource) handleListConnectorsError(ctx context.C
 	var bodyBytes []byte
 	if httpRes != nil && httpRes.Body != nil {
 		bodyBytes, _ = io.ReadAll(httpRes.Body)
+		httpRes.Body.Close()
 	}
 
 	statusCode := 0

--- a/internal/provider/resource_site.go
+++ b/internal/provider/resource_site.go
@@ -53,12 +53,18 @@ func (r *siteResource) Metadata(_ context.Context, req resource.MetadataRequest,
 }
 
 // Configure adds the provider configured client to the resource.
-func (r *siteResource) Configure(ctx context.Context, req resource.ConfigureRequest, _ *resource.ConfigureResponse) {
+func (r *siteResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	if req.ProviderData == nil {
 		return
 	}
 
-	r.client = *req.ProviderData.(*client.SSEClientFactory).GetSitesClient(ctx)
+	factory, ok := req.ProviderData.(*client.SSEClientFactory)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected Provider Data Type",
+			fmt.Sprintf("expected *client.SSEClientFactory, got %T", req.ProviderData))
+		return
+	}
+	r.client = *factory.GetSitesClient(ctx)
 }
 
 // Schema defines the schema for the resource.


### PR DESCRIPTION
Fixes various runtime errors raised by external review:

* Fixes closing HTTP response body in access policy Read and Delete
* Fixes 404 status checks missing err != nil guard
* Fixes Configure type assertion guards  by adding comma-ok
* Fixes closing HTTP responses
* Fixes reading response body before closing in handleListConnectorsError
* Fixes unhandled strconv.Atoi errors on private resource ID conversion
* Fixes propagatation of Synchronize errors to prevent silent state drift (resource_access_policy.go)
* Fixes diag reference in access_policy read()
* Fixes context propagation