### PR TITLE
test(resource_private_resource, resource_resource_connector_agent): e…

### DIFF
--- a/internal/provider/resource_private_resource_test.go
+++ b/internal/provider/resource_private_resource_test.go
@@ -5,14 +5,19 @@
 package provider
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"testing"
 
+	"github.com/CiscoDevNet/go-ciscosecureaccess/client"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // Test constants for private resource tests
@@ -49,7 +54,7 @@ func TestPrivateResourceResource_basic(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
-			//CheckDestroy:             testAccCheckPrivateResourceDestroy,
+			CheckDestroy: testAccCheckPrivateResourceDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccPrivateResourceConfig(rName, testAccessTypeNetwork),
@@ -72,7 +77,7 @@ func TestPrivateResourceResource_ztna(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
-			//CheckDestroy:             testAccCheckPrivateResourceDestroy,
+			CheckDestroy: testAccCheckPrivateResourceDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccPrivateResourceConfig(rName, testAccessTypeClient),
@@ -241,4 +246,27 @@ resource "ciscosecureaccess_private_resource" "test_resource" {
 		secondPort,
 		secondProtocol,
 	)
+}
+
+func testAccCheckPrivateResourceDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	factory := &client.SSEClientFactory{
+		KeyId:     os.Getenv("CISCOSECUREACCESS_KEY_ID"),
+		KeySecret: os.Getenv("CISCOSECUREACCESS_KEY_SECRET"),
+	}
+	c := factory.GetPrivateAppsClient(ctx)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ciscosecureaccess_private_resource" {
+			continue
+		}
+		id, err := strconv.ParseInt(rs.Primary.ID, 10, 64)
+		if err != nil {
+			continue
+		}
+		_, httpRes, _ := c.PrivateResourcesAPI.GetPrivateResource(ctx, id).Execute()
+		if httpRes == nil || httpRes.StatusCode != 404 {
+			return fmt.Errorf("private resource %d still exists after destroy", id)
+		}
+	}
+	return nil
 }

--- a/internal/provider/resource_resource_connector_agent_test.go
+++ b/internal/provider/resource_resource_connector_agent_test.go
@@ -5,15 +5,18 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/CiscoDevNet/go-ciscosecureaccess/client"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 // Test constants for resource connector agent tests
@@ -36,7 +39,7 @@ func TestResourceConnectorAgentResource_instanceID(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
-			//CheckDestroy:             testAccCheckResourceConnectorAgentDestroy,
+			CheckDestroy: testAccCheckResourceConnectorAgentDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccResourceConnectorAgentConfigInstanceID(rName, rName),
@@ -62,7 +65,7 @@ func TestResourceConnectorAgentResource_hostname(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
-			//CheckDestroy:             testAccCheckResourceConnectorAgentDestroy,
+			CheckDestroy: testAccCheckResourceConnectorAgentDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccResourceConnectorAgentConfigHostname(rName, rName),
@@ -88,7 +91,7 @@ func TestResourceConnectorAgentResource_enabled(t *testing.T) {
 		resource.Test(t, resource.TestCase{
 			PreCheck:                 func() { testAccPreCheck(t) },
 			ProtoV6ProviderFactories: testAccCiscoSecureAccessProviderFactories,
-			//CheckDestroy:             testAccCheckResourceConnectorAgentDestroy,
+			CheckDestroy: testAccCheckResourceConnectorAgentDestroy,
 			Steps: []resource.TestStep{
 				{
 					Config: testAccResourceConnectorAgentConfigEnabled(rName, rName, true),
@@ -167,4 +170,24 @@ resource "ciscosecureaccess_resource_connector_agent" "test_agent" {
   instance_id = "%s"
   confirmed   = %t
 }`, instanceID, confirmed)
+}
+
+func testAccCheckResourceConnectorAgentDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	factory := &client.SSEClientFactory{
+		KeyId:     os.Getenv("CISCOSECUREACCESS_KEY_ID"),
+		KeySecret: os.Getenv("CISCOSECUREACCESS_KEY_SECRET"),
+	}
+	c := factory.GetResConnClient(ctx)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ciscosecureaccess_resource_connector_agent" {
+			continue
+		}
+		id := atoi64(rs.Primary.ID)
+		_, httpRes, _ := c.ConnectorsAPI.GetConnector(ctx, id).Execute()
+		if httpRes == nil || httpRes.StatusCode != 404 {
+			return fmt.Errorf("resource connector agent %d still exists after destroy", id)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
…nable CheckDestroy

Changes to internal/provider/resource_private_resource_test.go:
- Enable CheckDestroy in TestPrivateResourceResource_basic and _ztna
- Add testAccCheckPrivateResourceDestroy helper

Changes to internal/provider/resource_resource_connector_agent_test.go:
- Enable CheckDestroy in TestResourceConnectorAgentResource_instanceID, _hostname, and _enabled
- Add testAccCheckResourceConnectorAgentDestroy helper